### PR TITLE
Removes check to verify that a .env file was loaded

### DIFF
--- a/src/env.ts
+++ b/src/env.ts
@@ -2,10 +2,6 @@ import { config } from "dotenv"
 
 const result = config()
 
-if (!result.parsed) {
-  throw Error("Unable to locate .env file")
-}
-
 const env = {
   database_url: process.env.DATABASE_URL as string,
   secret_key: process.env.SECRET_KEY as string,


### PR DESCRIPTION
Removes check to verify that a .env file as loaded, because environment varibales may come from other sources